### PR TITLE
password-validation

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -12,5 +12,6 @@
     "**/__pycache__": true
   },
   "python.formatting.provider": "autopep8",
-  "python.linting.enabled": true
+  "python.linting.enabled": true,
+  "python.pythonPath": "venv\\Scripts\\python.exe"
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -12,6 +12,5 @@
     "**/__pycache__": true
   },
   "python.formatting.provider": "autopep8",
-  "python.linting.enabled": true,
-  "python.pythonPath": "venv\\Scripts\\python.exe"
+  "python.linting.enabled": true
 }

--- a/features/Authentication/PasswordPolicy.feature
+++ b/features/Authentication/PasswordPolicy.feature
@@ -19,14 +19,6 @@ Fonctionnalité: Les mots de passe satisfont à la politique relative aux mots d
     - il contient au moins 8 caractères
     - il mélange des chiffres et des lettres
     - il contient au moins un caractère spécial
-    - il n'a pas été compromis
-
-    Un mot de passe est **compromis** s'il est connu comme ayant fuité sur Internet,
-    i.e. si l'outil
-
-    https://haveibeenpwned.com/Passwords
-
-    le renseigne comme "pwned".
 
     Etant donné le mot de passe <mot de passe non conforme>
     Alors il est non conforme
@@ -38,4 +30,3 @@ Fonctionnalité: Les mots de passe satisfont à la politique relative aux mots d
       | motdepassecompliqué       |
       | ufiDo_anCyx               |
       | blabli 89qw lala hI       |
-      | p@ssword1                 |

--- a/features/Authentication/RegisterConsumer.feature
+++ b/features/Authentication/RegisterConsumer.feature
@@ -2,9 +2,9 @@
 
 @initial-release @auth
 @fixture.signup
-Fonctionnalité: Enregistrer un nouveau client
+Fonctionnalité: Enregistrer un nouveau Consommateur
 
-  *En tant que nouveau client du Shopozor,  
+  *En tant que nouveau Consommateur du Shopozor,  
   je veux pouvoir y créer un compte avec un e-mail et un mot de passe,  
   afin d'avoir accès à toutes ses fonctionnalités.*  
 
@@ -24,9 +24,9 @@ Fonctionnalité: Enregistrer un nouveau client
   # de la méthode setPassword de l'API qu'il est plus judicieux de tester en tant que fonctionnalité en tant que telle
   # sans qu'elle ne soit couplée à quoi que ce soit d'autre.
 
-  Scénario: Un nouveau client s'enregistre avec un mot de passe conforme
+  Scénario: Un nouveau Consommateur s'enregistre avec un mot de passe conforme
 
-    Le client potentiel commence par donner un e-mail et un mot de passe. Il devra ensuite
+    Le Consommateur potentiel commence par donner un e-mail et un mot de passe. Il devra ensuite
     valider son e-mail en visitant un lien de confirmation qui lui y aura été envoyé. Dans
     l'intervalle, un compte inactif protégé par son mot de passe lui est créé.  
 
@@ -34,25 +34,25 @@ Fonctionnalité: Enregistrer un nouveau client
 
     <pre>http://www.shopozor.ch/activate/encodedUserId/token</pre>
 
-    Lorsqu'un client inconnu fait une demande d'enregistrement avec un mot de passe conforme
+    Lorsqu'un Consommateur inconnu fait une demande d'enregistrement avec un mot de passe conforme
     Alors il reçoit un e-mail avec un lien d'activation de compte
     Et son compte est créé
     Et son mot de passe est sauvegardé
     Mais son compte est inactif
 
 
-  Scénario: Un nouveau client s'enregistre avec un mot de passe non conforme
+  Scénario: Un nouveau Consommateur s'enregistre avec un mot de passe non conforme
 
-    Lorsqu'un client inconnu fait une demande d'enregistrement avec un mot de passe non conforme
+    Lorsqu'un Consommateur inconnu fait une demande d'enregistrement avec un mot de passe non conforme
     Alors il obtient un message d'erreur stipulant que son mot de passe n'est pas conforme à la politique des mots de passe
     Et son compte n'est pas créé
     Et il ne reçoit pas d'e-mail d'activation de compte
 
 
   @fixture.user-accounts  
-  Scénario: Le client a déjà un compte inactif et propose un mot de passe conforme
+  Scénario: Le Consommateur a déjà un compte inactif et propose un mot de passe conforme
 
-    Le client qui a déjà enregistré son e-mail et son mot de passe mais n'a pas réussi à
+    Le Consommateur qui a déjà enregistré son e-mail et son mot de passe mais n'a pas réussi à
     consulter son lien de confirmation dans les temps conserve un compte inactif. Il peut alors
     refaire une demande d'enregistrement et obtenir un nouveau lien d'activation de compte.
     Il peut spécifier un mot de passe différent lors de cette nouvelle demande.
@@ -64,7 +64,7 @@ Fonctionnalité: Enregistrer un nouveau client
 
 
   @fixture.user-accounts
-  Scénario: Le client a déjà un compte inactif et propose un mot de passe non conforme
+  Scénario: Le Consommateur a déjà un compte inactif et propose un mot de passe non conforme
 
     Si l'utilisateur propose un mot de passe non conforme, alors son compte ne s'active pas.
     Quoi qu'il arrive avec le mot de passe n'est pas vraiment important. Il peut être sauvé ou
@@ -81,8 +81,8 @@ Fonctionnalité: Enregistrer un nouveau client
   Scénario: Un utilisateur s'enregistre avec l'e-mail d'un compte actif
 
     Si un utilisateur tente de s'enregistrer avec un e-mail lié à un compte déjà actif,
-    il faut notifier le client correspondant à cet e-mail et inscrire l'incident
-    dans un journal car il se peut que ce client soit en train de se faire pirater
+    il faut notifier le Consommateur correspondant à cet e-mail et inscrire l'incident
+    dans un journal car il se peut que ce Consommateur soit en train de se faire pirater
     son compte. La notification est envoyée que le pirate potentiel ait entré un mot de
     passe conforme ou non.
 
@@ -96,37 +96,37 @@ Fonctionnalité: Enregistrer un nouveau client
     Et son mot de passe n'est pas sauvegardé
 
   @wip
-  Scénario: Le nouveau client active son compte dans les temps
+  Scénario: Le nouveau Consommateur active son compte dans les temps
 
     Au moment où l'utilisateur suit son lien d'activation, il s'invalide et son compte
     est activé.
 
-    Etant donné un nouveau client qui a reçu un lien d'activation de compte
+    Etant donné un nouveau Consommateur qui a reçu un lien d'activation de compte
     Lorsqu'il active son compte au plus tard 1 jour après sa réception
     Alors son compte est activé
     Et son lien d'activation est invalidé
     Mais il n'est pas identifié
 
   @wip
-  Scénario: Le nouveau client active son compte une deuxième fois
+  Scénario: Le nouveau Consommateur active son compte une deuxième fois
 
     Le lien d'activation de compte ne peut être utilisé qu'une seule fois,
     dans un certain laps de temps.
 
-    Etant donné un nouveau client qui a reçu un lien d'activation de compte
+    Etant donné un nouveau Consommateur qui a reçu un lien d'activation de compte
     Et qui a déjà activé son compte
     Lorsqu'il l'active pour la deuxième fois avant l'expiration du lien
     Alors il obtient un message d'erreur stipulant que le lien a expiré
 
   @wip
-  Scénario: Le nouveau client active son compte trop tard
+  Scénario: Le nouveau Consommateur active son compte trop tard
 
     En plus de n'être utilisable qu'une seule fois, le lien expire après un certain temps.
     Dans ce cas, l'utilisateur reste inactif avec un mot de passe, i.e. son compte n'est pas supprimé.
     Il a toujours la possibilité d'activer son compte en refaisant une demande d'enregistrement pour
     obtenir un nouveau lien, auquel cas il aura même la possibilité de spécifier un mot de passe différent.
 
-    Etant donné un nouveau client qui a reçu un lien d'activation de compte
+    Etant donné un nouveau Consommateur qui a reçu un lien d'activation de compte
     Lorsqu'il active son compte 2 jours après sa réception
     Alors il obtient un message d'erreur stipulant que le lien a expiré
     Et son compte reste inactif

--- a/features/Authentication/RegisterCustomer.feature
+++ b/features/Authentication/RegisterCustomer.feature
@@ -40,7 +40,7 @@ Fonctionnalité: Enregistrer un nouveau client
     Et son mot de passe est sauvegardé
     Mais son compte est inactif
 
-  @wip
+
   Scénario: Un nouveau client s'enregistre avec un mot de passe non conforme
 
     Lorsqu'un client inconnu fait une demande d'enregistrement avec un mot de passe non conforme
@@ -48,7 +48,7 @@ Fonctionnalité: Enregistrer un nouveau client
     Et son compte n'est pas créé
     Et il ne reçoit pas d'e-mail d'activation de compte
 
-  @wip
+
   @fixture.user-accounts  
   Scénario: Le client a déjà un compte inactif et propose un mot de passe conforme
 
@@ -62,7 +62,7 @@ Fonctionnalité: Enregistrer un nouveau client
     Et son mot de passe est sauvegardé
     Et son compte reste inactif
 
-  @wip
+
   @fixture.user-accounts
   Scénario: Le client a déjà un compte inactif et propose un mot de passe non conforme
 
@@ -76,7 +76,7 @@ Fonctionnalité: Enregistrer un nouveau client
     Et son compte reste inactif  
     Et il ne reçoit pas d'e-mail d'activation de compte
 
-  @wip
+
   @HackerAbuse @fixture.user-accounts
   Scénario: Un utilisateur s'enregistre avec l'e-mail d'un compte actif
 
@@ -93,6 +93,7 @@ Fonctionnalité: Enregistrer un nouveau client
     Alors il n'obtient aucun message d'erreur
     Et un message d'avertissement est envoyé à cet e-mail
     Et l'incident est enregistré dans un journal
+    Et son mot de passe n'est pas sauvegardé
 
   @wip
   Scénario: Le nouveau client active son compte dans les temps

--- a/features/Authentication/RegisterCustomer.feature
+++ b/features/Authentication/RegisterCustomer.feature
@@ -1,6 +1,6 @@
 #language: fr
 
-@initial-release @auth @wip
+@initial-release @auth
 @fixture.signup
 Fonctionnalité: Enregistrer un nouveau client
 
@@ -40,6 +40,7 @@ Fonctionnalité: Enregistrer un nouveau client
     Et son mot de passe est sauvegardé
     Mais son compte est inactif
 
+  @wip
   Scénario: Un nouveau client s'enregistre avec un mot de passe non conforme
 
     Lorsqu'un client inconnu fait une demande d'enregistrement avec un mot de passe non conforme
@@ -47,6 +48,7 @@ Fonctionnalité: Enregistrer un nouveau client
     Et son compte n'est pas créé
     Et il ne reçoit pas d'e-mail d'activation de compte
 
+  @wip
   @fixture.user-accounts  
   Scénario: Le client a déjà un compte inactif et propose un mot de passe conforme
 
@@ -60,6 +62,7 @@ Fonctionnalité: Enregistrer un nouveau client
     Et son mot de passe est sauvegardé
     Et son compte reste inactif
 
+  @wip
   @fixture.user-accounts
   Scénario: Le client a déjà un compte inactif et propose un mot de passe non conforme
 
@@ -73,6 +76,7 @@ Fonctionnalité: Enregistrer un nouveau client
     Et son compte reste inactif  
     Et il ne reçoit pas d'e-mail d'activation de compte
 
+  @wip
   @HackerAbuse @fixture.user-accounts
   Scénario: Un utilisateur s'enregistre avec l'e-mail d'un compte actif
 
@@ -90,6 +94,7 @@ Fonctionnalité: Enregistrer un nouveau client
     Et un message d'avertissement est envoyé à cet e-mail
     Et l'incident est enregistré dans un journal
 
+  @wip
   Scénario: Le nouveau client active son compte dans les temps
 
     Au moment où l'utilisateur suit son lien d'activation, il s'invalide et son compte
@@ -101,6 +106,7 @@ Fonctionnalité: Enregistrer un nouveau client
     Et son lien d'activation est invalidé
     Mais il n'est pas identifié
 
+  @wip
   Scénario: Le nouveau client active son compte une deuxième fois
 
     Le lien d'activation de compte ne peut être utilisé qu'une seule fois,
@@ -111,6 +117,7 @@ Fonctionnalité: Enregistrer un nouveau client
     Lorsqu'il l'active pour la deuxième fois avant l'expiration du lien
     Alors il obtient un message d'erreur stipulant que le lien a expiré
 
+  @wip
   Scénario: Le nouveau client active son compte trop tard
 
     En plus de n'être utilisable qu'une seule fois, le lien expire après un certain temps.

--- a/features/fixtures.py
+++ b/features/fixtures.py
@@ -160,7 +160,7 @@ def successful_account_confirmation(context):
 @fixture
 def successful_password_reset(context):
     data = get_data_from_json_fixture(os.path.join(
-        'Authentication', 'ResetUserPassword', 'SuccessfulPasswordReset.json'))
+        'Authentication', 'ResetUserPassword', 'Responses', 'SuccessfulPasswordReset.json'))
     context.successful_password_reset = data
     return data
 

--- a/features/fixtures.py
+++ b/features/fixtures.py
@@ -158,14 +158,6 @@ def successful_account_confirmation(context):
 
 
 @fixture
-def password_not_compliant_response(context):
-    data = get_data_from_json_fixture(
-        os.path.join('Authentication', 'RegisterConsumer', 'Responses', 'NonCompliantPassword.json'))
-    context.password_not_compliant_response = data
-    return data
-
-
-@fixture
 def successful_password_reset(context):
     data = get_data_from_json_fixture(os.path.join(
         'Authentication', 'ResetUserPassword', 'SuccessfulPasswordReset.json'))
@@ -206,8 +198,7 @@ def signup(context):
                                           fixture_call_params(
                                               expired_account_confirmation_link),
                                           fixture_call_params(
-                                              successful_account_confirmation),
-                                          fixture_call_params(password_not_compliant_response)])
+                                              successful_account_confirmation))])
 
 
 @fixture

--- a/features/fixtures.py
+++ b/features/fixtures.py
@@ -198,7 +198,7 @@ def signup(context):
                                           fixture_call_params(
                                               expired_account_confirmation_link),
                                           fixture_call_params(
-                                              successful_account_confirmation))])
+                                              successful_account_confirmation)])
 
 
 @fixture

--- a/features/settings.py
+++ b/features/settings.py
@@ -28,3 +28,6 @@ GRAPHQL_JWT = {
     'JWT_SECRET_KEY': JWT_SECRET_KEY,
     'JWT_ALGORITHM': JWT_ALGORITHM
 }
+
+DOMAIN_NAME = "shopozor.ch"
+EMAIL_BACKEND = 'django.core.mail.backends.locmem.EmailBackend'

--- a/features/settings.py
+++ b/features/settings.py
@@ -9,6 +9,7 @@ GRAPHQL_QUERIES_FOLDER = os.path.join('features', 'graphql')
 
 INSTALLED_APPS.append('behave_django')
 INSTALLED_APPS.append('features')
+INSTALLED_APPS.append('test_utils')
 
 ACCEPTANCE_TESTING = True
 

--- a/features/steps/common.py
+++ b/features/steps/common.py
@@ -3,4 +3,5 @@ from behave import then
 
 @then(u'il n\'obtient aucun message d\'erreur')
 def step_impl(context):
-    context.test.assertEqual(0, len(context.response['data']['errors']))
+    context.test.assertEqual(
+        0, len(context.response['data']['consumerCreate']['errors']))

--- a/features/steps/registerConsumer.py
+++ b/features/steps/registerConsumer.py
@@ -26,7 +26,7 @@ def activate_account(client, **kwargs):
     return get_graphql_content(response)
 
 
-@given(u'un nouveau client qui a reçu un lien d\'activation de compte')
+@given(u'un nouveau Consommateur qui a reçu un lien d\'activation de compte')
 def step_impl(context):
     context.current_user = context.unknown
     test_client = context.test.client
@@ -46,7 +46,7 @@ def step_impl(context):
         context.response['data'], context.successful_account_confirmation['data'])
 
 
-@when(u'un client inconnu fait une demande d\'enregistrement avec un mot de passe conforme')
+@when(u'un Consommateur inconnu fait une demande d\'enregistrement avec un mot de passe conforme')
 def step_impl(context):
     context.current_user = context.unknown
     assertPasswordIsCompliant(context.current_user['password'])
@@ -54,7 +54,7 @@ def step_impl(context):
     context.response = signup(test_client, **context.current_user)
 
 
-@when(u'un client inconnu fait une demande d\'enregistrement avec un mot de passe non conforme')
+@when(u'un Consommateur inconnu fait une demande d\'enregistrement avec un mot de passe non conforme')
 def step_impl(context):
     context.current_user = context.unknown
     context.current_user['password'] = 'password'

--- a/features/steps/registerCustomer.py
+++ b/features/steps/registerCustomer.py
@@ -176,7 +176,7 @@ def step_impl(context):
 
 @then(u'son mot de passe est sauvegardé')
 def step_impl(context):
-    user = User.objects.filter(email=context.unknown['email'])
+    user = User.objects.filter(email=context.current_user['email'])
     context.test.assertTrue(user.password)
 
 

--- a/features/steps/registerCustomer.py
+++ b/features/steps/registerCustomer.py
@@ -131,7 +131,7 @@ def step_impl(context):
 @then(u'son compte est créé')
 def step_impl(context):
     context.test.assertEqual(
-        len(context.response['data']['customerCreate']['errors']), 0)
+        len(context.response['data']['consumerCreate']['errors']), 0)
     context.test.assertTrue(account_exists(context.current_user['email']))
 
 
@@ -176,7 +176,7 @@ def step_impl(context):
 
 @then(u'son mot de passe est sauvegardé')
 def step_impl(context):
-    user = User.objects.filter(email=context.current_user['email'])
+    user = User.objects.filter(email=context.current_user['email']).get()
     context.test.assertTrue(user.password)
 
 

--- a/features/steps/registerCustomer.py
+++ b/features/steps/registerCustomer.py
@@ -55,6 +55,16 @@ def step_impl(context):
     context.response = signup(test_client, **context.current_user)
 
 
+@when(u'un client inconnu fait une demande d\'enregistrement avec un mot de passe non conforme')
+def step_impl(context):
+    context.current_user = context.unknown
+    context.current_user['password'] = 'password'
+    assertPasswordIsNotCompliant(
+        context.test, context.current_user['password'])
+    test_client = context.test.client
+    context.response = signup(test_client, **context.current_user)
+
+
 @when(u'un utilisateur fait une demande d\'enregistrement avec l\'e-mail d\'un compte inactif et un mot de passe conforme')
 def step_impl(context):
     context.current_user = context.inactive_customer
@@ -128,7 +138,7 @@ def step_impl(context):
         'message': 'PASSWORD_NOT_COMPLIANT'
     }
     context.test.assertTrue(
-        expected_error in context.response['data']['errors'])
+        expected_error in context.response['data']['consumerCreate']['errors'])
 
 
 @then(u'son compte est créé')

--- a/features/steps/registerCustomer.py
+++ b/features/steps/registerCustomer.py
@@ -1,5 +1,4 @@
-from behave import given, then, when
-from behave import use_fixture
+from behave import given, then, when, use_fixture
 from datetime import datetime, timedelta
 from django.core import mail
 from features.utils.auth.account_handling import get_current_encrypted_password, account_exists, is_active_account
@@ -124,8 +123,12 @@ def step_impl(context):
 
 @then(u'il obtient un message d\'erreur stipulant que son mot de passe n\'est pas conforme à la politique des mots de passe')
 def step_impl(context):
-    context.test.assertEqual(
-        context.password_not_compliant_response['data'], context.response['data'])
+    expected_error = {
+        'field': None,
+        'message': 'PASSWORD_NOT_COMPLIANT'
+    }
+    context.test.assertTrue(
+        expected_error in context.response['data']['errors'])
 
 
 @then(u'son compte est créé')

--- a/features/steps/registerCustomer.py
+++ b/features/steps/registerCustomer.py
@@ -4,7 +4,7 @@ from datetime import datetime, timedelta
 from django.core import mail
 from features.utils.auth.account_handling import get_current_encrypted_password, account_exists, is_active_account
 from features.utils.auth.credentials_checks import check_compulsory_login_credential_arguments, assertPasswordIsCompliant, assertPasswordIsNotCompliant
-from features.utils.auth.mail_confirmation import ActivationMailHandler, gather_email_activation_data, check_that_email_was_sent_to_user, check_that_email_is_received_soon_enough, check_compulsory_account_activation_credential_arguments
+from features.utils.auth.mail_confirmation import gather_email_activation_data, check_that_email_was_sent_to_user, check_that_email_is_received_soon_enough, check_compulsory_account_activation_credential_arguments
 from features.utils.graphql.loader import get_query_from_file
 from freezegun import freeze_time
 from saleor.account.models import User

--- a/features/steps/registerCustomer.py
+++ b/features/steps/registerCustomer.py
@@ -77,7 +77,7 @@ def step_impl(context):
     context.current_user = context.inactive_customer
     context.current_encrypted_password = get_current_encrypted_password(
         context.current_user['email'])
-    context.current_user['password'] = ''
+    context.current_user['password'] = 'password'
     assertPasswordIsNotCompliant(
         context.test, context.current_user['password'])
     test_client = context.test.client

--- a/features/steps/registerCustomer.py
+++ b/features/steps/registerCustomer.py
@@ -8,9 +8,8 @@ from features.utils.graphql.loader import get_query_from_file
 from freezegun import freeze_time
 from saleor.account.models import User
 from shopozor.models import HackerAbuseEvents
+from test_utils.url_utils import url_activate
 from tests.api.utils import get_graphql_content
-
-activation_url_prefix = 'activate'
 
 
 def signup(client, **kwargs):
@@ -34,7 +33,7 @@ def step_impl(context):
     context.response = signup(test_client, **context.current_user)
     check_that_email_was_sent_to_user(
         context.test, context.current_user['email'])
-    context.credentials = gather_email_activation_data(activation_url_prefix)
+    context.credentials = gather_email_activation_data(url_activate())
     context.test.assertIsNotNone(context.credentials)
     context.email_reception_time = datetime.now()
 
@@ -89,6 +88,8 @@ def step_impl(context):
 def step_impl(context):
     # in this case, the choice of the password is irrelevant; it must only comply to the password policy
     context.current_user = context.consumer
+    context.current_encrypted_password = get_current_encrypted_password(
+        context.current_user['email'])
     assertPasswordIsCompliant(context.current_user['password'])
     test_client = context.test.client
     context.response = signup(test_client, **context.current_user)
@@ -127,7 +128,7 @@ def step_impl(context):
     context.test.assertEqual(context.successful_signup, context.response)
     check_that_email_was_sent_to_user(
         context.test, context.current_user['email'])
-    credentials = gather_email_activation_data(activation_url_prefix)
+    credentials = gather_email_activation_data(url_activate())
     context.test.assertIsNotNone(credentials)
 
 

--- a/features/steps/resetUserPassword.py
+++ b/features/steps/resetUserPassword.py
@@ -144,7 +144,7 @@ def step_impl(context):
 
 @then(u'son mot de passe reste inchangé')
 def step_impl(context):
-    user = User.objects.filter(email=context.current_user['email'])
+    user = User.objects.filter(email=context.current_user['email']).get()
     context.test.assertEqual(
         context.current_user['encrypted_password'], user.password)
 

--- a/features/steps/resetUserPassword.py
+++ b/features/steps/resetUserPassword.py
@@ -8,11 +8,10 @@ from features.utils.auth.password_generation import RandomCompliantPasswordGener
 from features.utils.graphql.loader import get_query_from_file
 from freezegun import freeze_time
 from saleor.account.models import User
+from test_utils.url_utils import url_reset
 from tests.api.utils import get_graphql_content
 
 import features.types
-
-activation_url_prefix = 'reset'
 
 
 def reset_password(client, user_email):
@@ -52,7 +51,7 @@ def step_impl(context, persona):
         test_client, context.current_user['email'])
     check_that_email_was_sent_to_user(
         context.test, context.current_user['email'])
-    context.credentials = gather_email_activation_data(activation_url_prefix)
+    context.credentials = gather_email_activation_data(url_reset())
     context.test.assertIsNotNone(context.credentials)
     context.email_reception_time = datetime.now()
 
@@ -136,7 +135,7 @@ def step_impl(context, amount, unit):
 def step_impl(context):
     check_that_email_was_sent_to_user(
         context.test, context.current_user['email'])
-    credentials = gather_email_activation_data(activation_url_prefix)
+    credentials = gather_email_activation_data(url_reset())
     context.test.assertIsNotNone(credentials)
     context.test.assertEqual(
         context.successful_password_reset, context.response)

--- a/features/utils/auth/account_handling.py
+++ b/features/utils/auth/account_handling.py
@@ -25,7 +25,7 @@ def create_database_superuser(user_data):
 
 
 def get_current_encrypted_password(email):
-    user = User.objects.filter(email=email)
+    user = User.objects.filter(email=email).get()
     return user.password
 
 
@@ -34,5 +34,5 @@ def account_exists(email):
 
 
 def is_active_account(email):
-    user = User.objects.filter(email=email)
+    user = User.objects.filter(email=email).get()
     return user.is_active

--- a/features/utils/auth/mail_confirmation.py
+++ b/features/utils/auth/mail_confirmation.py
@@ -1,6 +1,8 @@
 from datetime import datetime
 from django.core import mail
 
+from test_utils.regex_utils import regex_url_uid_token
+
 import re
 
 
@@ -38,10 +40,8 @@ def gather_email_activation_data(activation_url_prefix):
 
 
 class ActivationMailHandler:
-    __url_suffix_pattern = r'\/(?P<uidb64>[0-9A-Za-z_\-]+)\/(?P<token>[0-9A-Za-z]{1,13}-[0-9A-Za-z]{1,20})'
-
     def __init__(self, url_prefix):
-        self.url_pattern = re.escape(url_prefix) + self.__url_suffix_pattern
+        self.url_pattern = re.escape(url_prefix) + regex_url_uid_token()
 
     def get_credentials(self, mail_body):
         match = re.search(self.url_pattern, mail_body)

--- a/features/utils/auth/mail_confirmation.py
+++ b/features/utils/auth/mail_confirmation.py
@@ -38,7 +38,7 @@ def gather_email_activation_data(activation_url_prefix):
 
 
 class ActivationMailHandler:
-    __url_suffix_pattern = r'\/(?P<uidb64>[0-9A-Za-z_\-]+)\/(?P<token>[0-9A-Za-z]{1,13}-[0-9A-Za-z]{1,20})\/'
+    __url_suffix_pattern = r'\/(?P<uidb64>[0-9A-Za-z_\-]+)\/(?P<token>[0-9A-Za-z]{1,13}-[0-9A-Za-z]{1,20})'
 
     def __init__(self, url_prefix):
         self.url_pattern = re.escape(url_prefix) + self.__url_suffix_pattern

--- a/shopozor/emails.py
+++ b/shopozor/emails.py
@@ -1,3 +1,5 @@
+from datetime import datetime
+
 from django.conf import settings
 from django.contrib.auth.tokens import default_token_generator
 from django.contrib.sites.models import Site
@@ -24,6 +26,25 @@ def send_activate_account_email(pk):
         'domain': current_site.get("domain"),
         'uid': uid,
         'token': token,
+    })
+    email = EmailMessage(
+        mail_subject, message, from_email=settings.DEFAULT_FROM_EMAIL, to=[
+            email]
+    )
+    email.send()
+
+
+def send_hacker_abuse_email_notification(email):
+    current_site = get_email_base_context()
+    mail_subject = 'Someone tried to create a user account with your email.'
+    time_event = datetime.now()
+    message = render_to_string('hacker_abuse_email.html', {
+        'domain': current_site.get("domain"),
+        'day': time_event.day,
+        'month': time_event.month,
+        'year': time_event.year,
+        'hour': time_event.hour,
+        'minute': time_event.minute
     })
     email = EmailMessage(
         mail_subject, message, from_email=settings.DEFAULT_FROM_EMAIL, to=[

--- a/shopozor/emails.py
+++ b/shopozor/emails.py
@@ -1,0 +1,32 @@
+from django.conf import settings
+from django.contrib.auth.tokens import default_token_generator
+from django.contrib.sites.models import Site
+from django.core.mail import EmailMessage
+from django.template.loader import render_to_string
+from django.utils.encoding import force_bytes
+from django.utils.http import urlsafe_base64_encode
+from saleor.account.models import User
+
+
+def get_email_base_context():
+    site = Site.objects.get_current()
+    return {"domain": site.domain, "site_name": site.name}
+
+
+def send_activate_account_email(pk):
+    user = User.objects.get(pk=pk)
+    email = user.email
+    uid = urlsafe_base64_encode(force_bytes(user.pk))
+    token = default_token_generator.make_token(user)
+    current_site = get_email_base_context()
+    mail_subject = 'Activate your customer account.'
+    message = render_to_string('acc_active_email.html', {
+        'domain': current_site.get("domain"),
+        'uid': uid,
+        'token': token,
+    })
+    email = EmailMessage(
+        mail_subject, message, from_email=settings.DEFAULT_FROM_EMAIL, to=[
+            email]
+    )
+    email.send()

--- a/shopozor/exceptions.py
+++ b/shopozor/exceptions.py
@@ -1,0 +1,5 @@
+class HackerAbuseException(Exception):
+    def __init__(self, user, instance):
+        self.user = user
+        self.instance = instance
+        super().__init__()

--- a/shopozor/exceptions.py
+++ b/shopozor/exceptions.py
@@ -1,5 +1,5 @@
 class HackerAbuseException(Exception):
-    def __init__(self, user, instance):
+    def __init__(self, user, model):
         self.user = user
-        self.instance = instance
+        self.model = model
         super().__init__()

--- a/shopozor/graphql/auth/mutations.py
+++ b/shopozor/graphql/auth/mutations.py
@@ -70,7 +70,6 @@ class ConsumerCreate(ModelMutation):
 
     class Meta:
         description = "Register a new consumer."
-        exclude = ["password"]
         model = models.User
 
     @classmethod

--- a/shopozor/graphql/auth/schema.py
+++ b/shopozor/graphql/auth/schema.py
@@ -29,7 +29,7 @@ from saleor.graphql.account.resolvers import resolve_address_validator, resolve_
 from saleor.graphql.account.types import AddressValidationData, User
 from saleor.graphql.account.schema import CustomerFilterInput, StaffUserInput
 from saleor.graphql.core.mutations import VerifyToken
-from shopozor.graphql.auth.mutations import Login
+from shopozor.graphql.auth.mutations import Login, ConsumerCreate
 
 import graphene
 
@@ -97,6 +97,8 @@ class AuthMutations(graphene.ObjectType):
             then it is invalidated.""")
     token_verify = VerifyToken.Field(
         description="Verifies if an authentication token is valid.")
+    consumer_create = ConsumerCreate.Field(
+        description="Creates a new consumer.")
 
     # password_reset = PasswordReset.Field()
     # set_password = SetPassword.Field()

--- a/shopozor/password_validation.py
+++ b/shopozor/password_validation.py
@@ -63,21 +63,20 @@ class HasBeenPwndValidator:
         prefix = hashed_password[:5]
         suffix = hashed_password[5:]
         # only send a prefix of 5 chars to haveibeenpwnd.com
+        response = requests.get(range_url.format(prefix), headers).text
+        return not suffix.upper() in response
+
+    def validate(self, password, user=None):
         try:
-            response = requests.get(range_url.format(prefix), headers).text
+            if not self.is_valid_password(password):
+                raise ValidationError(
+                    _(self.error_string),
+                    code=self.error_code,
+                )
         except requests.exceptions.RequestException:
             raise ValidationError(
                 _("We could not get a successful answer from haveibeenpwnd.com."),
                 code=self.error_not_reachable,
-            )
-        return not suffix.upper() in response
-
-    def validate(self, password, user=None):
-
-        if not self.is_valid_password(password):
-            raise ValidationError(
-                _(self.error_string),
-                code=self.error_code,
             )
 
     def get_help_text(self):

--- a/shopozor/settings.py
+++ b/shopozor/settings.py
@@ -44,25 +44,3 @@ TEST_RUNNER = "unit_tests.runner.PytestTestRunner"
 # For now on and for local purpose, we set the following variable
 DOMAIN_NAME = "shopozor.ch"
 EMAIL_BACKEND = 'django.core.mail.backends.locmem.EmailBackend'
-"""
-EMAIL_URL = os.environ.get("EMAIL_URL")
-SENDGRID_USERNAME = os.environ.get("SENDGRID_USERNAME")
-SENDGRID_PASSWORD = os.environ.get("SENDGRID_PASSWORD")
-if not EMAIL_URL and SENDGRID_USERNAME and SENDGRID_PASSWORD:
-    EMAIL_URL = "smtp://%s:%s@smtp.sendgrid.net:587/?tls=True" % (
-        SENDGRID_USERNAME,
-        SENDGRID_PASSWORD,
-    )
-email_config = dj_email_url.parse(EMAIL_URL or "console://")
-
-EMAIL_FILE_PATH = email_config["EMAIL_FILE_PATH"]
-EMAIL_HOST_USER = email_config["EMAIL_HOST_USER"]
-EMAIL_HOST_PASSWORD = email_config["EMAIL_HOST_PASSWORD"]
-EMAIL_HOST = email_config["EMAIL_HOST"]
-EMAIL_PORT = email_config["EMAIL_PORT"]
-EMAIL_BACKEND = email_config["EMAIL_BACKEND"]
-EMAIL_USE_TLS = email_config["EMAIL_USE_TLS"]
-EMAIL_USE_SSL = email_config["EMAIL_USE_SSL"]
-
-DEFAULT_FROM_EMAIL = os.environ.get("DEFAULT_FROM_EMAIL", EMAIL_HOST_USER)
-"""

--- a/shopozor/settings.py
+++ b/shopozor/settings.py
@@ -35,8 +35,3 @@ AUTH_PASSWORD_VALIDATORS = [
 ]
 
 TEST_RUNNER = "unit_tests.runner.PytestTestRunner"
-
-# We need to configure the EMAIL_URL and everything following
-# For now on and for local purpose, we set the following variable
-DOMAIN_NAME = "shopozor.ch"
-EMAIL_BACKEND = 'django.core.mail.backends.locmem.EmailBackend'

--- a/shopozor/settings.py
+++ b/shopozor/settings.py
@@ -31,11 +31,7 @@ AUTH_PASSWORD_VALIDATORS = [
     },
     {
         'NAME': 'shopozor.password_validation.NumberAndLetterValidator',
-    },
-    # This must be last in list because an exception is raised if the site is inacessible
-    {
-        'NAME': 'shopozor.password_validation.HasBeenPwndValidator',
-    },
+    }
 ]
 
 TEST_RUNNER = "unit_tests.runner.PytestTestRunner"

--- a/shopozor/settings.py
+++ b/shopozor/settings.py
@@ -1,5 +1,6 @@
 from saleor.settings import *
 from datetime import timedelta
+import dj_email_url
 
 if DEBUG:
     CORS_ORIGIN_ALLOW_ALL = True
@@ -38,3 +39,30 @@ AUTH_PASSWORD_VALIDATORS = [
 ]
 
 TEST_RUNNER = "unit_tests.runner.PytestTestRunner"
+
+# We need to configure the EMAIL_URL and everything following
+# For now on and for local purpose, we set the following variable
+DOMAIN_NAME = "shopozor.ch"
+EMAIL_BACKEND = 'django.core.mail.backends.locmem.EmailBackend'
+"""
+EMAIL_URL = os.environ.get("EMAIL_URL")
+SENDGRID_USERNAME = os.environ.get("SENDGRID_USERNAME")
+SENDGRID_PASSWORD = os.environ.get("SENDGRID_PASSWORD")
+if not EMAIL_URL and SENDGRID_USERNAME and SENDGRID_PASSWORD:
+    EMAIL_URL = "smtp://%s:%s@smtp.sendgrid.net:587/?tls=True" % (
+        SENDGRID_USERNAME,
+        SENDGRID_PASSWORD,
+    )
+email_config = dj_email_url.parse(EMAIL_URL or "console://")
+
+EMAIL_FILE_PATH = email_config["EMAIL_FILE_PATH"]
+EMAIL_HOST_USER = email_config["EMAIL_HOST_USER"]
+EMAIL_HOST_PASSWORD = email_config["EMAIL_HOST_PASSWORD"]
+EMAIL_HOST = email_config["EMAIL_HOST"]
+EMAIL_PORT = email_config["EMAIL_PORT"]
+EMAIL_BACKEND = email_config["EMAIL_BACKEND"]
+EMAIL_USE_TLS = email_config["EMAIL_USE_TLS"]
+EMAIL_USE_SSL = email_config["EMAIL_USE_SSL"]
+
+DEFAULT_FROM_EMAIL = os.environ.get("DEFAULT_FROM_EMAIL", EMAIL_HOST_USER)
+"""

--- a/shopozor/templates/acc_active_email.html
+++ b/shopozor/templates/acc_active_email.html
@@ -1,0 +1,5 @@
+{% autoescape off %}
+Hi,
+Please click on the link to confirm your registration,
+http://{{ domain }}/activate/{{ uid }}/{{ token }}
+{% endautoescape %}

--- a/shopozor/templates/hacker_abuse_email.html
+++ b/shopozor/templates/hacker_abuse_email.html
@@ -1,0 +1,4 @@
+{% autoescape off %}
+Hi,
+We inform you that someone tries to create a new account on http://{{ domain }} with your email account the {{ day }}/{{ month }}/{{ year }} at {{ hour }}:{{ minute }}
+{% endautoescape %}

--- a/test_utils/regex_utils.py
+++ b/test_utils/regex_utils.py
@@ -1,0 +1,2 @@
+def regex_url_uid_token():
+    return r'\/(?P<uidb64>[0-9A-Za-z_\-]+)\/(?P<token>[0-9A-Za-z]{1,13}-[0-9A-Za-z]{1,20})'

--- a/test_utils/url_utils.py
+++ b/test_utils/url_utils.py
@@ -1,0 +1,6 @@
+def url_activate():
+    return 'activate'
+
+
+def url_reset():
+    return 'reset'

--- a/unit_testing.groovy
+++ b/unit_testing.groovy
@@ -44,7 +44,7 @@ pipeline {
     stage('Performing shopozor unit tests') {
       environment {
         DATABASE_URL = credentials('postgres-credentials')
-        DJANGO_SETTINGS_MODULE = 'tests.settings'
+        DJANGO_SETTINGS_MODULE = 'unit_tests.settings'
         PYTHONPATH = "$PYTHONPATH:$WORKSPACE/saleor"
       }
       steps {

--- a/unit_tests/conftest.py
+++ b/unit_tests/conftest.py
@@ -1,8 +1,35 @@
-# from unittest.mock import MagicMock, Mock
+from unittest.mock import MagicMock, Mock
 
-# import pytest
+import pytest
 
+from django.conf import settings
+from django.contrib.sites.models import Site
+
+from saleor.account.models import User
+from saleor.site.models import SiteSettings
 
 # @pytest.fixture
 # def checkout(db):
 #     return Checkout.objects.create()
+
+
+@pytest.fixture(autouse=True)
+def site_settings(db, settings):
+    """Create a site and matching site settings.
+
+    This fixture is autouse because django.contrib.sites.models.Site and
+    saleor.site.models.SiteSettings have a one-to-one relationship and a site
+    should never exist without a matching settings object.
+    """
+    site = Site.objects.get_or_create(
+        name=settings.DOMAIN_NAME, domain=settings.DOMAIN_NAME)[0]
+    obj = SiteSettings.objects.get_or_create(site=site)[0]
+    settings.SITE_ID = site.pk
+    obj.save()
+    return obj
+
+
+@pytest.fixture
+def customer_user(db):
+    user = User.objects.create_user("test@example.com", "password")
+    return user

--- a/unit_tests/conftest.py
+++ b/unit_tests/conftest.py
@@ -27,5 +27,5 @@ def site_settings(db, settings):
 
 @pytest.fixture
 def customer_user(db):
-    user = User.objects.create_user("test@example.com", "password")
+    user = User.objects.create_user("test@example.com")
     return user

--- a/unit_tests/conftest.py
+++ b/unit_tests/conftest.py
@@ -8,10 +8,6 @@ from django.contrib.sites.models import Site
 from saleor.account.models import User
 from saleor.site.models import SiteSettings
 
-# @pytest.fixture
-# def checkout(db):
-#     return Checkout.objects.create()
-
 
 @pytest.fixture(autouse=True)
 def site_settings(db, settings):

--- a/unit_tests/settings.py
+++ b/unit_tests/settings.py
@@ -13,6 +13,8 @@ LANGUAGE_CODE = "en"
 DOMAIN_NAME = "shopozor.ch"
 EMAIL_BACKEND = 'django.core.mail.backends.locmem.EmailBackend'
 
+INSTALLED_APPS.append('test_utils')
+
 # ES_URL = None
 # SEARCH_BACKEND = "saleor.search.backends.postgresql"
 # INSTALLED_APPS = [a for a in INSTALLED_APPS if a != "django_elasticsearch_dsl"]

--- a/unit_tests/settings.py
+++ b/unit_tests/settings.py
@@ -10,6 +10,9 @@ SECRET_KEY = "NOTREALLY"
 
 LANGUAGE_CODE = "en"
 
+DOMAIN_NAME = "shopozor.ch"
+EMAIL_BACKEND = 'django.core.mail.backends.locmem.EmailBackend'
+
 # ES_URL = None
 # SEARCH_BACKEND = "saleor.search.backends.postgresql"
 # INSTALLED_APPS = [a for a in INSTALLED_APPS if a != "django_elasticsearch_dsl"]

--- a/unit_tests/test_emails.py
+++ b/unit_tests/test_emails.py
@@ -21,7 +21,6 @@ def test_get_email_base_context(site_settings):
 
 def test_send_activate_account_email(customer_user):
     send_activate_account_email(customer_user.pk)
-    print(mail.outbox[0].body)
     assert len(mail.outbox) == 1
 
 

--- a/unit_tests/test_emails.py
+++ b/unit_tests/test_emails.py
@@ -1,0 +1,39 @@
+import pytest
+import re
+
+from django.contrib.auth.tokens import default_token_generator
+from django.core import mail
+from django.utils.http import urlsafe_base64_decode
+from saleor.account.models import User
+from shopozor.emails import send_activate_account_email, get_email_base_context
+
+
+def test_get_email_base_context(site_settings):
+    site = site_settings.site
+    proper_context = {
+        "domain": site.domain,
+        "site_name": site.name,
+    }
+
+    received_context = get_email_base_context()
+    assert proper_context == received_context
+
+
+def test_send_activate_account_email(customer_user):
+    send_activate_account_email(customer_user.pk)
+    print(mail.outbox[0].body)
+    assert len(mail.outbox) == 1
+
+
+def test_activate_account_email_correct_url(customer_user):
+    send_activate_account_email(customer_user.pk)
+    mail_sent = mail.outbox[0].body
+    url_split = re.findall(
+        'http[s]?://(?:[a-zA-Z]|[0-9]|[$-_@.&+]|[!*\(\),]|(?:%[0-9a-fA-F][0-9a-fA-F]))+', mail_sent)[0].split('/')
+
+    token = url_split[-1]
+    assert default_token_generator.check_token(customer_user, token)
+
+    uid_decoded = urlsafe_base64_decode(url_split[-2]).decode()
+    decoded_user = User.objects.get(pk=uid_decoded)
+    assert customer_user == decoded_user

--- a/unit_tests/test_password_validators.py
+++ b/unit_tests/test_password_validators.py
@@ -1,9 +1,27 @@
 from django.core.exceptions import ValidationError
+from django.contrib.auth.password_validation import MinimumLengthValidator
 from shopozor.password_validation import NumberAndLetterValidator, SpecialCharacterValidator, HasBeenPwndValidator
 
 import pytest
 
 # password database:"@sdf","@asdf1","@*123","fdsjlkwern23","p@ssword","p@ssword1","@123","asdf1234"
+
+
+@pytest.mark.parametrize(
+    "password_has_been_pwnd_up_and_valid",
+    [
+        "@sdfHj@#"
+    ],
+)
+def test_has_been_pwn_up_and_running(password_has_been_pwnd_up_and_valid):
+    try:
+        HasBeenPwndValidator().is_valid_password(password_has_been_pwnd_up_and_valid)
+        assert True
+    except ValidationError as exception:
+        if exception.code == HasBeenPwndValidator().error_not_reachable:
+            assert False
+        else:  # the password is pwnd => the website is up and running
+            assert True
 
 
 @pytest.mark.parametrize(

--- a/unit_tests/test_password_validators.py
+++ b/unit_tests/test_password_validators.py
@@ -1,101 +1,57 @@
-from django.core.exceptions import ValidationError
-from django.contrib.auth.password_validation import MinimumLengthValidator
+from django.contrib.auth.password_validation import MinimumLengthValidator, ValidationError
 from shopozor.password_validation import NumberAndLetterValidator, SpecialCharacterValidator, HasBeenPwndValidator
 
 import pytest
 
-# password database:"@sdf","@asdf1","@*123","fdsjlkwern23","p@ssword","p@ssword1","@123","asdf1234"
-
 
 @pytest.mark.parametrize(
-    "password_has_been_pwnd_up_and_valid",
-    [
-        "@sdfHj@#"
-    ],
-)
-def test_has_been_pwn_up_and_running(password_has_been_pwnd_up_and_valid):
-    try:
-        HasBeenPwndValidator().is_valid_password(password_has_been_pwnd_up_and_valid)
-        assert True
-    except ValidationError as exception:
-        if exception.code == HasBeenPwndValidator().error_not_reachable:
-            assert False
-        else:  # the password is pwnd => the website is up and running
-            assert True
-
-
-@pytest.mark.parametrize(
-    "password_has_been_pwnd_valid",
-    [
-        "@sdf", "@asdf1", "@*123", "fdsjlkwern23"
-    ],
-)
-def test_has_been_pwn_valid(password_has_been_pwnd_valid):
-    try:
-        assert HasBeenPwndValidator().is_valid_password(password_has_been_pwnd_valid)
-    except ValidationError as exception:
-        if exception.code == HasBeenPwndValidator().error_not_reachable:
-            assert True
-        else:
-            assert False
-
-
-@pytest.mark.parametrize(
-    "password_has_been_pwnd_not_valid",
+    "pwned_password",
     [
         "p@ssword", "p@ssword1", "@123", "asdf1234"
     ],
 )
-def test_has_been_pwn_not_valid(password_has_been_pwnd_not_valid):
-    try:
-        assert not HasBeenPwndValidator().is_valid_password(
-            password_has_been_pwnd_not_valid)
-    except ValidationError as exception:
-        if exception.code == HasBeenPwndValidator().error_not_reachable:
-            assert True
-        else:
-            assert False
+def test_has_been_pwnd_not_valid(pwned_password):
+    with pytest.raises(ValidationError):
+        HasBeenPwndValidator().validate(pwned_password)
 
 
 @pytest.mark.parametrize(
-    "password_number_and_letter_valid",
+    "valid_password",
     [
         "@asdf1", "p@ssword1", "fdsjlkwern23", "asdf1234"
     ],
 )
-def test_number_and_letter_validator_valid(password_number_and_letter_valid):
-    assert NumberAndLetterValidator().is_valid_password(
-        password_number_and_letter_valid)
+def test_number_and_letter_validator_valid(valid_password):
+    NumberAndLetterValidator().validate(valid_password)
 
 
 @pytest.mark.parametrize(
-    "password_number_and_letter_not_valid",
+    "invalid_password",
     [
         "@sdf", "@*123", "p@ssword", "@123"
     ],
 )
-def test_number_and_letter_validator_not_valid(password_number_and_letter_not_valid):
-    assert not NumberAndLetterValidator().is_valid_password(
-        password_number_and_letter_not_valid)
+def test_number_and_letter_validator_not_valid(invalid_password):
+    with pytest.raises(ValidationError):
+        NumberAndLetterValidator().validate(invalid_password)
 
 
 @pytest.mark.parametrize(
-    "password_special_character_valid",
+    "valid_password",
     [
         "@sdf", "@asdf1", "@*123", "p@ssword", "p@ssword1", "@123"
     ],
 )
-def test_special_character_validator_valid(password_special_character_valid):
-    assert SpecialCharacterValidator().is_valid_password(
-        password_special_character_valid)
+def test_special_character_validator_valid(valid_password):
+    SpecialCharacterValidator().validate(valid_password)
 
 
 @pytest.mark.parametrize(
-    "password_special_character_not_valid",
+    "invalid_password",
     [
         "fdsjlkwern23", "asdf1234"
     ],
 )
-def test_special_character_validator_not_valid(password_special_character_not_valid):
-    assert not SpecialCharacterValidator().is_valid_password(
-        password_special_character_not_valid)
+def test_special_character_validator_not_valid(invalid_password):
+    with pytest.raises(ValidationError):
+        SpecialCharacterValidator().validate(invalid_password)

--- a/unit_tests/test_password_validators.py
+++ b/unit_tests/test_password_validators.py
@@ -1,0 +1,83 @@
+from django.core.exceptions import ValidationError
+from shopozor.password_validation import NumberAndLetterValidator, SpecialCharacterValidator, HasBeenPwndValidator
+
+import pytest
+
+# password database:"@sdf","@asdf1","@*123","fdsjlkwern23","p@ssword","p@ssword1","@123","asdf1234"
+
+
+@pytest.mark.parametrize(
+    "password_has_been_pwnd_valid",
+    [
+        "@sdf", "@asdf1", "@*123", "fdsjlkwern23"
+    ],
+)
+def test_has_been_pwn_valid(password_has_been_pwnd_valid):
+    try:
+        assert HasBeenPwndValidator().is_valid_password(password_has_been_pwnd_valid)
+    except ValidationError as exception:
+        if exception.code == HasBeenPwndValidator().error_not_reachable:
+            assert True
+        else:
+            assert False
+
+
+@pytest.mark.parametrize(
+    "password_has_been_pwnd_not_valid",
+    [
+        "p@ssword", "p@ssword1", "@123", "asdf1234"
+    ],
+)
+def test_has_been_pwn_not_valid(password_has_been_pwnd_not_valid):
+    try:
+        assert not HasBeenPwndValidator().is_valid_password(
+            password_has_been_pwnd_not_valid)
+    except ValidationError as exception:
+        if exception.code == HasBeenPwndValidator().error_not_reachable:
+            assert True
+        else:
+            assert False
+
+
+@pytest.mark.parametrize(
+    "password_number_and_letter_valid",
+    [
+        "@asdf1", "p@ssword1", "fdsjlkwern23", "asdf1234"
+    ],
+)
+def test_number_and_letter_validator_valid(password_number_and_letter_valid):
+    assert NumberAndLetterValidator().is_valid_password(
+        password_number_and_letter_valid)
+
+
+@pytest.mark.parametrize(
+    "password_number_and_letter_not_valid",
+    [
+        "@sdf", "@*123", "p@ssword", "@123"
+    ],
+)
+def test_number_and_letter_validator_not_valid(password_number_and_letter_not_valid):
+    assert not NumberAndLetterValidator().is_valid_password(
+        password_number_and_letter_not_valid)
+
+
+@pytest.mark.parametrize(
+    "password_special_character_valid",
+    [
+        "@sdf", "@asdf1", "@*123", "p@ssword", "p@ssword1", "@123"
+    ],
+)
+def test_special_character_validator_valid(password_special_character_valid):
+    assert SpecialCharacterValidator().is_valid_password(
+        password_special_character_valid)
+
+
+@pytest.mark.parametrize(
+    "password_special_character_not_valid",
+    [
+        "fdsjlkwern23", "asdf1234"
+    ],
+)
+def test_special_character_validator_not_valid(password_special_character_not_valid):
+    assert not SpecialCharacterValidator().is_valid_password(
+        password_special_character_not_valid)

--- a/unit_tests/test_url_decoding.py
+++ b/unit_tests/test_url_decoding.py
@@ -24,3 +24,12 @@ def test_encoded_userid_should_be_decoded_from_url(user_id):
     encoded_user_id = urlsafe_base64_encode(force_bytes(user_id))
     decoded_user_id = force_text(urlsafe_base64_decode(encoded_user_id))
     assert user_id == int(decoded_user_id)
+
+
+@pytest.mark.django_db
+def test_encoded_user_should_be_decoded_from_url():
+    user = User.objects.create_user(email='test@shopozor.ch')
+    encoded_user_id = urlsafe_base64_encode(force_bytes(user.id))
+    decoded_user_id = urlsafe_base64_decode(encoded_user_id).decode()
+    decoded_user = User.objects.get(pk=decoded_user_id)
+    assert user == decoded_user


### PR DESCRIPTION
- modify validators to allow unit testing
- implementation of unit tests

- implementation of the consumer signup and the tests

[Recap of our workflow](https://github.com/softozor/shopozor-backend#pull-requests)

# Prerequisites

- [x] You have configured the triggering of the pre-commit hook on your local repository's clone. You need to have installed the python module `pre-commit` (listed in [the required dev modules](requirements-dev.txt)) and run the command `pre-commit install` in the repository's root folder.
- [x] You have covered your code with unit and acceptance tests
- [x] The feature you have implemented has no tag `@wip` any more

# Changes

Reworking of validators to allow unit testing of them. Implementation of the unit tests
Added a new mutation to create a consumer
Added sending email activation and unit tests

# How to use the feature

Run the test_password_validators.py to run the unit test and see that everyting passes. Do the same with the acceptance tests

Run the scenario "Un nouveau client s'enregistre avec un mot de passe conforme"

