### PR TITLE
rework the way we use the expiry links

### DIFF
--- a/features/fixtures.py
+++ b/features/fixtures.py
@@ -165,7 +165,7 @@ def signup_password_not_compliant(context):
     data = json.load(
         os.path.join(settings.GRAPHQL_RESPONSES_FOLDER, 'Authentication', 'SignupPasswordNotCompliant.json'))
     password_not_compliant = data['data']['consumerCreate']['errors']
-    context.password_not_compliant = password_not_compliant
+    context.password_not_compliant = password_not_compliant[0]
     return password_not_compliant
 
 
@@ -173,7 +173,7 @@ def signup_password_not_compliant(context):
 def password_reset_password_not_compliant(context):
     data = json.load(
         os.path.join(settings.GRAPHQL_RESPONSES_FOLDER, 'Authentication', 'PasswordResetPasswordNotCompliant.json'))
-    password_not_compliant = data['data']['setPassword']['errors']
+    password_not_compliant = data['data']['setPassword']['errors'][0]
     context.password_not_compliant = password_not_compliant
     return password_not_compliant
 

--- a/features/fixtures.py
+++ b/features/fixtures.py
@@ -164,8 +164,8 @@ def successful_set_password(context):
 def signup_password_not_compliant(context):
     data = json.load(
         os.path.join(settings.GRAPHQL_RESPONSES_FOLDER, 'Authentication', 'SignupPasswordNotCompliant.json'))
-    password_not_compliant = data['data']['consumerCreate']['errors']
-    context.password_not_compliant = password_not_compliant[0]
+    password_not_compliant = data['data']['consumerCreate']['errors'][0]
+    context.password_not_compliant = password_not_compliant
     return password_not_compliant
 
 

--- a/features/fixtures.py
+++ b/features/fixtures.py
@@ -161,11 +161,21 @@ def successful_set_password(context):
 
 
 @fixture
-def password_not_compliant(context):
+def signup_password_not_compliant(context):
     data = json.load(
-        os.path.join(settings.GRAPHQL_RESPONSES_FOLDER, 'Authentication', 'PasswordNotCompliant.json'))
-    context.password_not_compliant = data
-    return data
+        os.path.join(settings.GRAPHQL_RESPONSES_FOLDER, 'Authentication', 'SignupPasswordNotCompliant.json'))
+    password_not_compliant = data['data']['consumerCreate']['errors']
+    context.password_not_compliant = password_not_compliant
+    return password_not_compliant
+
+
+@fixture
+def password_reset_password_not_compliant(context):
+    data = json.load(
+        os.path.join(settings.GRAPHQL_RESPONSES_FOLDER, 'Authentication', 'PasswordResetPasswordNotCompliant.json'))
+    password_not_compliant = data['data']['setPassword']['errors']
+    context.password_not_compliant = password_not_compliant
+    return password_not_compliant
 
 
 @fixture
@@ -204,7 +214,7 @@ def signup(context):
                                           signup_expired_link),
                                        fixture_call_params(
                                           successful_account_confirmation),
-                                       fixture_call_params(password_not_compliant)])
+                                       fixture_call_params(signup_password_not_compliant)])
 
 
 @fixture
@@ -213,7 +223,7 @@ def password_reset(context):
                                                 fixture_call_params(
                                                     successful_set_password),
                                                 fixture_call_params(
-                                                    password_not_compliant),
+                                                    password_reset_password_not_compliant),
                                                 fixture_call_params(
                                                     password_reset_expired_link),
                                                 fixture_call_params(successful_password_reset)])

--- a/features/fixtures.py
+++ b/features/fixtures.py
@@ -169,11 +169,21 @@ def password_not_compliant(context):
 
 
 @fixture
-def expired_link(context):
+def signup_expired_link(context):
     data = json.load(
-        os.path.join(settings.GRAPHQL_RESPONSES_FOLDER, 'Authentication', 'ExpiredLink.json'))
-    context.expired_link = data
-    return data
+        os.path.join(settings.GRAPHQL_RESPONSES_FOLDER, 'Authentication', 'SignupExpiredLink.json'))
+    expired_link = data['data']['consumerActivate']
+    context.expired_link = expired_link
+    return expired_link
+
+
+@fixture
+def password_reset_expired_link(context):
+    data = json.load(
+        os.path.join(settings.GRAPHQL_RESPONSES_FOLDER, 'Authentication', 'PasswordResetExpiredLink.json'))
+    expired_link = data['data']['setPassword']
+    context.expired_link = expired_link
+    return expired_link
 
 
 @fixture
@@ -191,7 +201,7 @@ def signup(context):
                                       [fixture_call_params(unknown),
                                        fixture_call_params(successful_signup),
                                        fixture_call_params(
-                                          expired_link),
+                                          signup_expired_link),
                                        fixture_call_params(
                                           successful_account_confirmation),
                                        fixture_call_params(password_not_compliant)])
@@ -205,7 +215,7 @@ def password_reset(context):
                                                 fixture_call_params(
                                                     password_not_compliant),
                                                 fixture_call_params(
-                                                    expired_link),
+                                                    password_reset_expired_link),
                                                 fixture_call_params(successful_password_reset)])
 
 


### PR DESCRIPTION
[Recap of our workflow](https://github.com/softozor/shopozor-backend#pull-requests)

# Prerequisites

- [x] You have configured the triggering of the pre-commit hook on your local repository's clone. You need to have installed the python module `pre-commit` (listed in [the required dev modules](requirements-dev.txt)) and run the command `pre-commit install` in the repository's root folder.
- [x] You have covered your code with unit and acceptance tests
- [x] The feature you have implemented has no tag `@wip` any more

# Changes

Out of the old `ExpiryLink.json` fixture, I created the `PasswordResetExpiryLink.json` and `SignupExpiryLink.json` fixtures. This is because the frontend applications need those fixtures like that for the sake of testing. I kept the backend acceptance test code as is, I've just reworked the fixture injection, so that the common checks can still be performed without code duplication.