### PR TITLE
get rid of isStaff flag in login mutation

### DIFF
--- a/features/Authentication/LogUserIn.feature
+++ b/features/Authentication/LogUserIn.feature
@@ -24,62 +24,37 @@ Fonctionnalité: Identifier un utilisateur
     - Rex
     - Softozor
 
+  N'importe quel administrateur peut s'identifier en tant que client.
+  Si l'identification est réussie, alors la session s'ouvre pour un certain temps.
+  Durant cette période, la session doit être rafraîchie :  
+
+  - Si la session n'est pas rafraîchie dans les temps, alors elle se ferme automatiquement et l'utilisateur doit s'identifier à nouveau.  
+
+  - Si la session est rafraîchie dans les temps, alors elle reste valide 1 mois de plus, et ainsi de suite, tant qu'elle est rafraîchie dans les temps.
+    La session se ferme alors automatiquement après 1 année. Après 1 année de rafraîchissement de session, l'utilisateur est forcé de s'identifier à nouveau.
+
   Contexte: L'utilisateur n'est pas identifié
 
     Etant donné un utilisateur non identifié sur le Shopozor
 
-  Plan du Scénario: L'utilisateur n'est pas encore enregistré
+  Scénario: L'utilisateur n'est pas encore enregistré
 
-    Lorsqu'un <utilisateur> s'identifie en tant que <utilisateur prétendu> avec un e-mail et un mot de passe invalides
+    Lorsqu'un utilisateur s'identifie avec un e-mail et un mot de passe invalides
     Alors il obtient un message d'erreur stipulant que ses identifiants sont incorrects
-
-    Exemples:
-      | utilisateur    | utilisateur prétendu |
-      | client         | client               |
-      | administrateur | client               |
-      | client         | administrateur       |
-      | administrateur | administrateur       |
 
   @fixture.user-accounts
   Plan du Scénario: L'utilisateur est enregistré mais entre un mot de passe erroné
 
-    Lorsqu'un <utilisateur> s'identifie en tant que <utilisateur prétendu> avec un e-mail valide et un mot de passe invalide
+    Lorsqu'un <persona> s'identifie avec un e-mail valide et un mot de passe invalide
     Alors il obtient un message d'erreur stipulant que ses identifiants sont incorrects
 
     Exemples:
-      | utilisateur    | utilisateur prétendu |
-      | client         | client               |
-      | administrateur | client               |
-      | client         | administrateur       |
-      | administrateur | administrateur       |
-
-  @fixture.user-accounts
-  Plan du Scénario: L'utilisateur peut s'identifier avec son identifiant et son mot de passe
-
-    N'importe quel administrateur peut s'identifier en tant que client.
-    Si l'identification est réussie, alors la session s'ouvre pour un certain temps.
-    Durant cette période, la session doit être rafraîchie.  
-
-    - Si la session n'est pas rafraîchie dans les temps, alors elle se ferme automatiquement et l'utilisateur doit s'identifier à nouveau.  
-
-    - Si la session est rafraîchie dans les temps, alors elle reste valide 1 mois de plus, et ainsi de suite, tant qu'elle est rafraîchie dans les temps.
-      La session se ferme alors automatiquement après 1 année. Après 1 année de rafraîchissement de session, l'utilisateur est forcé de s'identifier à nouveau.
-
-    Lorsqu'un <utilisateur> s'identifie en tant que <utilisateur prétendu> avec un e-mail et un mot de passe valides
-    Alors sa session s'ouvre pour 1 mois
-    Et reste valide pendant 1 an
-
-    Exemples:
-      | utilisateur    | utilisateur prétendu |
-      | client         | client               |
-      | administrateur | administrateur       |
-      | administrateur | client               |
-
-  @fixture.user-accounts
-  Scénario: Un client ne peut pas s'identifier en tant qu'administrateur
-
-    Lorsqu'un client s'identifie en tant qu'administrateur avec un e-mail et un mot de passe valides
-    Alors il obtient un message d'erreur stipulant que son compte n'a pas les droits d'administrateur
+      | persona      |
+      | Consommateur |
+      | Producteur   |
+      | Responsable  |
+      | Rex          |
+      | Softozor     |
 
   @fixture.user-accounts
   Plan du Scénario: Définition des permissions du Consommateur et du Producteur

--- a/features/fixtures.py
+++ b/features/fixtures.py
@@ -99,16 +99,8 @@ def user_accounts(context):
 @fixture
 def wrong_credentials_response(context):
     data = json.load(
-        os.path.join(settings.GRAPHQL_RESPONSES_FOLDER, 'Authentication', 'LogStaffIn', 'WrongCredentials.json'))
+        os.path.join(settings.GRAPHQL_RESPONSES_FOLDER, 'Authentication', 'Login', 'WrongCredentials.json'))
     context.wrong_credentials_response = data
-    return data
-
-
-@fixture
-def user_not_admin_response(context):
-    data = json.load(
-        os.path.join(settings.GRAPHQL_RESPONSES_FOLDER, 'Authentication', 'LogStaffIn', 'Consommateur.json'))
-    context.user_not_admin_response = data
     return data
 
 
@@ -201,8 +193,7 @@ def login(context):
     return use_composite_fixture_with(context,
                                       [fixture_call_params(unknown),
                                        fixture_call_params(
-                                           wrong_credentials_response),
-                                          fixture_call_params(user_not_admin_response)])
+                                           wrong_credentials_response)])
 
 
 @fixture

--- a/shopozor/graphql/auth/mutations.py
+++ b/shopozor/graphql/auth/mutations.py
@@ -25,16 +25,6 @@ def to_node_global_id(**data):
 
 class Login(CreateToken):
 
-    class Arguments:
-        is_staff = graphene.Boolean(
-            description="""Set this field to true if you want to authenticate as a staff member.
-                This field is used to access administration-relevant functionality. Users with insufficient
-                credentials cannot access admin functionality. For example, a Consumer who's not
-                a staff member and tries to access admin functionality by setting that field to true
-                will get ungranted access. That prevents e.g. a Consumer from accessing the administration panels.
-                Such panels log users in by setting that field to true. If the users are not staff members,
-                their access is not granted.""")
-
     @classmethod
     def mutate(cls, root, info, **kwargs):
 
@@ -56,13 +46,7 @@ class Login(CreateToken):
         if not password:
             return Login(errors=[Error(message='WRONG_CREDENTIALS')])
 
-        # make the is_staff check
-        wants_to_login_as_staff = kwargs.get('is_staff', False)
-        email = kwargs['email']
-        if wants_to_login_as_staff and User.objects.filter(email=email, is_staff=True).first() is None:
-            return Login(errors=[Error(message='USER_NOT_ADMIN')])
-        else:
-            return result
+        return result
 
 
 class ConsumerCreateInput(graphene.InputObjectType):


### PR DESCRIPTION
[Recap of our workflow](https://github.com/softozor/shopozor-backend#pull-requests)

# Prerequisites

- [x] You have configured the triggering of the pre-commit hook on your local repository's clone. You need to have installed the python module `pre-commit` (listed in [the required dev modules](requirements-dev.txt)) and run the command `pre-commit install` in the repository's root folder.
- [x] You have covered your code with unit and acceptance tests
- [x] The feature you have implemented has no tag `@wip` any more

# Changes

We have recently decided to go with only one frontend, because the security issues we identified with that pattern are not really a big deal in the end. Therefore, logging in as admin or client is not relevant any more. The frontend adapts based on user permissions, that's it. 
