### PR TITLE
set root as default USER on local dev and improve Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ db.migrate.status:
 
 fixtures.generate:
 	@echo "Generating fixtures ..."
-	@if [ -d fixtures ]; then rm -rf $(FIXTURES_FOLDER); fi
+	@if [ -d $(FIXTURES_FOLDER) ]; then rm -rf $(FIXTURES_FOLDER); fi
 	@mkdir $(FIXTURES_FOLDER)
 	@docker-compose -f docker-compose-tests.yaml -f docker-compose-tests-dev.yaml up fixtures-service
 	@docker-compose -f docker-compose-tests.yaml rm -f fixtures-service

--- a/Makefile
+++ b/Makefile
@@ -6,11 +6,12 @@ FIXTURES_MIGRATIONS_FOLDER = $(FIXTURES_FOLDER)/migrations
 
 dev.start: up fixtures
 
-dev.end: down fixtures.clean
+dev.end: down fixtures.clean rm
 
 build:
 	@echo "Building images..."
 	@docker-compose build
+	@docker-compose -f docker-compose-tests.yaml build
 
 up: build
 	@echo "Starting containers..."
@@ -22,6 +23,12 @@ up: build
 
 down:
 	@docker-compose down
+	@docker-compose -f docker-compose-tests.yaml down
+
+rm:
+	@docker-compose rm -f
+	@docker-compose -f docker-compose-tests.yaml rm -f
+
 
 db.migrate.apply:
 	$(HASURA_MIGRATE_APPLY) --project database-service
@@ -31,7 +38,9 @@ db.migrate.status:
 
 fixtures.generate:
 	@echo "Generating fixtures ..."
-	@docker-compose -f docker-compose-tests.yaml up fixtures-service
+	@if [ -d fixtures ]; then rm -rf fixtures; fi
+	@mkdir fixtures
+	@docker-compose -f docker-compose-tests.yaml -f docker-compose-tests-dev.yaml up fixtures-service
 	@docker-compose -f docker-compose-tests.yaml rm -f fixtures-service
 
 fixtures.up:

--- a/Makefile
+++ b/Makefile
@@ -38,8 +38,8 @@ db.migrate.status:
 
 fixtures.generate:
 	@echo "Generating fixtures ..."
-	@if [ -d fixtures ]; then rm -rf fixtures; fi
-	@mkdir fixtures
+	@if [ -d fixtures ]; then rm -rf $(FIXTURES_FOLDER); fi
+	@mkdir $(FIXTURES_FOLDER)
 	@docker-compose -f docker-compose-tests.yaml -f docker-compose-tests-dev.yaml up fixtures-service
 	@docker-compose -f docker-compose-tests.yaml rm -f fixtures-service
 

--- a/docker-compose-tests-dev.yaml
+++ b/docker-compose-tests-dev.yaml
@@ -1,0 +1,4 @@
+version: "3.6"
+services:
+  fixtures-service:
+    user: "root"


### PR DESCRIPTION
[Recap of our workflow](https://softozor.github.io/github_workflow.html)

# Prerequisites

- [x] You have configured the triggering of the pre-commit hook on your local repository's clone. You need to have installed the python module `pre-commit` (listed in [the required dev modules](requirements-dev.txt)) and run the command `pre-commit install` in the repository's root folder.
- [ ] You have covered your code with unit and acceptance tests
- [ ] The feature you have implemented has no tag `@wip` any more

# Changes

For local dev, user `root` is used as default for running the fixture generation container. Moreover, some improvement have been done in the `Makefile` that further improve the dev experience.

# How to use the feature

A new command `make rm` has been added to remove all containers.

