### PR TITLE
Stop exposing unnecessary ports during tests

### DIFF
--- a/Test.groovy
+++ b/Test.groovy
@@ -1,6 +1,9 @@
 pipeline {
   agent any
   stages {
+    environment {
+      API_PORT = 8081
+    }
     stage('Build the docker images') {
       steps {
         sh "docker-compose -f docker-compose-tests.yaml build"
@@ -17,9 +20,6 @@ pipeline {
       }
     }
     stage('Start GraphQL engine') {
-      environment {
-        API_PORT = 8081
-      }
       steps {
         sh "docker-compose -f docker-compose-tests.yaml up -d postgres graphql-engine"
         sh "chmod u+x ./database-service/scripts/waitForService.sh && ./database-service/scripts/waitForService.sh localhost ${API_PORT}"

--- a/Test.groovy
+++ b/Test.groovy
@@ -1,9 +1,9 @@
 pipeline {
   agent any
+  environment {
+    API_PORT = 8081
+  }
   stages {
-    environment {
-      API_PORT = 8081
-    }
     stage('Build the docker images') {
       steps {
         sh "docker-compose -f docker-compose-tests.yaml build"

--- a/Test.groovy
+++ b/Test.groovy
@@ -17,9 +17,12 @@ pipeline {
       }
     }
     stage('Start GraphQL engine') {
+      environment {
+        API_PORT = 8081
+      }
       steps {
         sh "docker-compose -f docker-compose-tests.yaml up -d postgres graphql-engine"
-        sh "chmod u+x ./database-service/scripts/waitForService.sh && ./database-service/scripts/waitForService.sh localhost 9000"
+        sh "chmod u+x ./database-service/scripts/waitForService.sh && ./database-service/scripts/waitForService.sh localhost ${API_PORT}"
       }
     }
     stage('Test GraphQL engine') {

--- a/docker-compose-tests-dev.yaml
+++ b/docker-compose-tests-dev.yaml
@@ -2,6 +2,3 @@ version: "3.6"
 services:
   fixtures-service:
     user: "root"
-  graphql-engine:
-    ports:
-      - "8080:8080"

--- a/docker-compose-tests-dev.yaml
+++ b/docker-compose-tests-dev.yaml
@@ -2,3 +2,6 @@ version: "3.6"
 services:
   fixtures-service:
     user: "root"
+  graphql-engine:
+    ports:
+      - "8080:8080"

--- a/docker-compose-tests.yaml
+++ b/docker-compose-tests.yaml
@@ -7,8 +7,6 @@ services:
       - db_data:/var/lib/postgresql-test/data
   graphql-engine:
     image: hasura/graphql-engine:v1.0.0-beta.9
-    ports:
-      - 9000:8080
     depends_on:
       - postgres
     restart: "always"

--- a/docker-compose-tests.yaml
+++ b/docker-compose-tests.yaml
@@ -7,6 +7,8 @@ services:
       - db_data:/var/lib/postgresql-test/data
   graphql-engine:
     image: hasura/graphql-engine:v1.0.0-beta.9
+    ports:
+      - "${API_PORT:-8080}:8080"
     depends_on:
       - postgres
     restart: "always"


### PR DESCRIPTION
[Recap of our workflow](https://softozor.github.io/github_workflow.html)

# Prerequisites

- [x] You have configured the triggering of the pre-commit hook on your local repository's clone. You need to have installed the python module `pre-commit` (listed in [the required dev modules](requirements-dev.txt)) and run the command `pre-commit install` in the repository's root folder.
- [ ] You have covered your code with unit and acceptance tests
- [ ] The feature you have implemented has no tag `@wip` any more

# Changes

Use more flexible port definition for the `graphql-engine` service during the tests, as it is can be 8080 for development purposes. I find it cleaner with an environment variable. 

# How to use the feature

Continue to use the `make test` command to perform tests on development environments. In the jenkins pipelines, just define an environment variable with the desired graphql engine port, so that it doesn't collide with jenkins'. 